### PR TITLE
Add Automatic Royal Guard toggle (Dante gameplay)

### DIFF
--- a/src/CrimsonConfigGameplay.hpp
+++ b/src/CrimsonConfigGameplay.hpp
@@ -102,6 +102,7 @@ struct CrimsonConfigGameplay {
 			bool skyLaunchAirTaunt = true;
 			bool dmc4Mobility = true;
 			bool dTInfusedRoyalguard = true;
+			bool automaticRoyalGuard = false;
 			bool airHikeCoreAbility = true;
 			bool altNevanVortex = true;
 			bool artemisRework = true;
@@ -133,6 +134,7 @@ struct CrimsonConfigGameplay {
 					std::make_pair("skyLaunchAirTaunt", &Dante::skyLaunchAirTaunt),
 					std::make_pair("dmc4Mobility", &Dante::dmc4Mobility),
 					std::make_pair("dTInfusedRoyalguard", &Dante::dTInfusedRoyalguard),
+					std::make_pair("automaticRoyalGuard", &Dante::automaticRoyalGuard),
 					std::make_pair("airHikeCoreAbility", &Dante::airHikeCoreAbility),
 					std::make_pair("altNevanVortex", &Dante::altNevanVortex),
 					std::make_pair("artemisRework", &Dante::artemisRework),

--- a/src/CrimsonConfigGameplayMask.hpp
+++ b/src/CrimsonConfigGameplayMask.hpp
@@ -73,6 +73,7 @@ struct CrimsonConfigGameplayMask {
 			bool skyLaunchAirTaunt = true;
 			bool dmc4Mobility = true;
 			bool dTInfusedRoyalguard = true;
+			bool automaticRoyalGuard = true;
 			bool airHikeCoreAbility = true;
 			bool altNevanVortex = true;
 			bool artemisRework = true;
@@ -104,6 +105,7 @@ struct CrimsonConfigGameplayMask {
 					std::make_pair("skyLaunchAirTaunt", &Dante::skyLaunchAirTaunt),
 					std::make_pair("dmc4Mobility", &Dante::dmc4Mobility),
 					std::make_pair("dTInfusedRoyalguard", &Dante::dTInfusedRoyalguard),
+					std::make_pair("automaticRoyalGuard", &Dante::automaticRoyalGuard),
 					std::make_pair("airHikeCoreAbility", &Dante::airHikeCoreAbility),
 					std::make_pair("altNevanVortex", &Dante::altNevanVortex),
 					std::make_pair("artemisRework", &Dante::artemisRework),

--- a/src/CrimsonGUI.cpp
+++ b/src/CrimsonGUI.cpp
@@ -11963,6 +11963,21 @@ void DanteGameplayOptions() {
 			ImGui::TableNextColumn();
 
 			GUI_PushDisable(!activeConfig.Actor.enable);
+			if (GUI_Checkbox2("Automatic Royal Guard",
+				activeCrimsonGameplay.Gameplay.Dante.automaticRoyalGuard,
+				queuedCrimsonGameplay.Gameplay.Dante.automaticRoyalGuard,
+				activeCrimsonGameplayMask.Gameplay.Dante.automaticRoyalGuard)) {
+			}
+			ImGui::SameLine();
+			GUI_CCSRequirementButton();
+			ImGui::SameLine();
+			TooltipHelper("(?)", "While in Royalguard style, Dante automatically Royal Blocks "
+				"incoming attacks with no input - no damage taken. Switch styles to attack.");
+			GUI_PopDisable(!activeConfig.Actor.enable);
+
+			ImGui::TableNextColumn();
+
+			GUI_PushDisable(!activeConfig.Actor.enable);
 			if (GUI_Checkbox2("Aerial Moves Tweaks",
 				activeCrimsonGameplay.Gameplay.Dante.aerialMovesTweaks,
 				queuedCrimsonGameplay.Gameplay.Dante.aerialMovesTweaks,

--- a/src/CrimsonGameplay.cpp
+++ b/src/CrimsonGameplay.cpp
@@ -1153,7 +1153,8 @@ void ImprovedCancelsRoyalguardController(byte8* actorBaseAddr) {
 		}
 		else if (bufferRoyal > BUFFER_ROYAL::ROYAL_BLOCK ||
 			(actorData.style == STYLE::ROYALGUARD &&
-				(actorData.buttons[0] & GetBinding(BINDING::STYLE_ACTION)))) {
+				((actorData.buttons[0] & GetBinding(BINDING::STYLE_ACTION)) ||
+				 activeCrimsonGameplay.Gameplay.Dante.automaticRoyalGuard))) {
 
 			func_1E0800_TriggerEvent(actorData, ACTOR_EVENT::ROYALGUARD_BLOCK, 0, 0);
 
@@ -1185,7 +1186,9 @@ void ImprovedCancelsRoyalguardController(byte8* actorBaseAddr) {
 			func_1E0800_TriggerEvent(actorData, ACTOR_EVENT::ATTACK, 0, 0);
 		}
 		else if (bufferRoyal == BUFFER_ROYAL::ROYAL_AIR_BLOCK ||
-			actorData.style == STYLE::ROYALGUARD && (actorData.buttons[0] & GetBinding(BINDING::STYLE_ACTION)) &&
+			actorData.style == STYLE::ROYALGUARD &&
+			((actorData.buttons[0] & GetBinding(BINDING::STYLE_ACTION)) ||
+			 activeCrimsonGameplay.Gameplay.Dante.automaticRoyalGuard) &&
 			actorData.eventData[0].event != ACTOR_EVENT::LANDING) {
 			if (actorData.action == EBONY_IVORY_AIR_NORMAL_SHOT && actorData.eventData[0].event != ACTOR_EVENT::ROYALGUARD_BLOCK) {
 				actorData.airGunAttackCount += 5;
@@ -4675,6 +4678,29 @@ void StopSprintAbility(byte8* actorBaseAddr) {
 #include <chrono>
 
 void DTInfusedRoyalguardController(byte8* actorBaseAddr) {
+	// --- Automatic Royal Guard: DMC4-style code patch on the player hit-handler. ---
+	// Forces the block-result the game computes to "perfect royal block" (eax=3), so every
+	// incoming attack is Royal Blocked with no input + no damage. It is just a byte patch the
+	// game runs on its own thread -> cannot crash, unlike CALLING the block function.
+	//   dmc3.exe+0x1EC455:  call <block-eval> (E8 D6 1F 00 00)  ->  mov eax,3 (B8 03 00 00 00)
+	{
+		static bool s_argApplied = false;
+		bool want = activeCrimsonGameplay.Gameplay.Dante.automaticRoyalGuard;
+		if (want != s_argApplied) {
+			uint8* a = (uint8*)appBaseAddr + 0x1EC455;
+			const uint8 patchBytes[5] = { 0xB8, 0x03, 0x00, 0x00, 0x00 }; // mov eax,3
+			const uint8 origBytes[5]  = { 0xE8, 0xD6, 0x1F, 0x00, 0x00 }; // call <block-eval>
+			const uint8* src = want ? patchBytes : origBytes;
+			DWORD oldProt;
+			if (VirtualProtect(a, 5, PAGE_EXECUTE_READWRITE, &oldProt)) {
+				for (int i = 0; i < 5; i++) a[i] = src[i];
+				VirtualProtect(a, 5, oldProt, &oldProt);
+				FlushInstructionCache(GetCurrentProcess(), a, 5);
+				s_argApplied = want;
+			}
+		}
+	}
+
 	// This makes normal block consume DT instead of health, when DT is above 0,
 	// guard breaks occur only when DT is exhausted
 


### PR DESCRIPTION
## What
Adds an **Automatic Royal Guard** toggle under **Dante → Gameplay**.

While in Royalguard style, Dante automatically performs a perfect Royal Block on every incoming attack — no input required, no damage taken. Switch styles to attack.

## How
Forces the block-evaluator result to a perfect block on the player hit-handler, so each incoming hit is treated as a perfect Royal Block. Wired through the existing config/mask/GUI plumbing (CrimsonConfigGameplay, CrimsonConfigGameplayMask, CrimsonGUI) alongside the other Dante gameplay options.

## Files
- `CrimsonConfigGameplay.hpp` / `CrimsonConfigGameplayMask.hpp` — new `automaticRoyalGuard` field + metadata
- `CrimsonGameplay.cpp` — the auto-block logic
- `CrimsonGUI.cpp` — the checkbox + tooltip under Dante gameplay

## Tested
Built and tested on DMC3 HD Collection. Happy to reshape the inline patch into the project's detour/patch style if you'd prefer.